### PR TITLE
Introduce quick hack that introduces in-memory cache 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation platform('androidx.compose:compose-bom:2022.12.00')
 
     implementation "androidx.datastore:datastore-preferences:1.0.0"
+
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'com.google.android.material:material:1.7.0'

--- a/app/src/main/java/flights/interstellar/admin/api/ApClientInterface.kt
+++ b/app/src/main/java/flights/interstellar/admin/api/ApClientInterface.kt
@@ -1,9 +1,11 @@
 package flights.interstellar.admin.api
 
 import flights.interstellar.admin.api.pojo.InstanceInfo
+import flights.interstellar.admin.api.pojo.InstanceUrl
 import flights.interstellar.admin.api.pojo.InstanceUserInfo
+import flights.interstellar.admin.api.pojo.UserHandle
 
 interface ApClientInterface {
-    suspend fun getUserInfo(instanceBaseUrl: String, handle: String): InstanceUserInfo
-    suspend fun getInstanceInfo(instanceBaseUrl: String): InstanceInfo
+    suspend fun getUserInfo(instanceBaseUrl: InstanceUrl, handle: UserHandle): InstanceUserInfo
+    suspend fun getInstanceInfo(instanceBaseUrl: InstanceUrl): InstanceInfo
 }

--- a/app/src/main/java/flights/interstellar/admin/api/client/ApClient.kt
+++ b/app/src/main/java/flights/interstellar/admin/api/client/ApClient.kt
@@ -2,7 +2,9 @@ package flights.interstellar.admin.api.client
 
 import flights.interstellar.admin.api.ApClientInterface
 import flights.interstellar.admin.api.pojo.InstanceInfo
+import flights.interstellar.admin.api.pojo.InstanceUrl
 import flights.interstellar.admin.api.pojo.InstanceUserInfo
+import flights.interstellar.admin.api.pojo.UserHandle
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -17,7 +19,10 @@ val apClient = ApClient()
 class ApClient : ApClientInterface {
     private val json = Json { ignoreUnknownKeys = true }
 
-    override suspend fun getUserInfo(instanceBaseUrl: String, handle: String): InstanceUserInfo {
+    override suspend fun getUserInfo(
+        instanceBaseUrl: InstanceUrl,
+        handle: UserHandle
+    ): InstanceUserInfo {
         //TODO: Refactor createRequest to properly handle query params
         val request = createRequest(
             apiBaseUrl = instanceBaseUrl,
@@ -31,7 +36,7 @@ class ApClient : ApClientInterface {
         }
     }
 
-    override suspend fun getInstanceInfo(instanceBaseUrl: String): InstanceInfo {
+    override suspend fun getInstanceInfo(instanceBaseUrl: InstanceUrl): InstanceInfo {
         val request =
             createRequest(apiBaseUrl = instanceBaseUrl, path = "api/v1", endpointName = "instance")
 
@@ -44,7 +49,7 @@ class ApClient : ApClientInterface {
 }
 
 private fun createRequest(
-    apiBaseUrl: String,
+    apiBaseUrl: InstanceUrl,
     path: String = "api/v1",
     endpointName: String
 ): Request {

--- a/app/src/main/java/flights/interstellar/admin/api/pojo/TypeAlias.kt
+++ b/app/src/main/java/flights/interstellar/admin/api/pojo/TypeAlias.kt
@@ -2,3 +2,6 @@ package flights.interstellar.admin.api.pojo
 
 typealias Actor = String
 typealias InstanceUrl = String
+typealias UserHandle = String
+
+typealias InstanceBaseUrlAdminHandlePair = Pair<InstanceUrl, UserHandle>

--- a/app/src/main/java/flights/interstellar/admin/features/allowedInstance/Screen.kt
+++ b/app/src/main/java/flights/interstellar/admin/features/allowedInstance/Screen.kt
@@ -28,11 +28,11 @@ import com.google.accompanist.placeholder.PlaceholderHighlight
 import com.google.accompanist.placeholder.material.fade
 import com.google.accompanist.placeholder.material.placeholder
 import flights.interstellar.admin.R
-import flights.interstellar.admin.api.client.apClient
 import flights.interstellar.admin.api.pojo.InstanceInfo
 import flights.interstellar.admin.common.InterstallarAdminTheme
 import flights.interstellar.admin.common.Purple80
 import flights.interstellar.admin.common.Typography
+import flights.interstellar.admin.repository.instanceInfoRepository
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -227,8 +227,9 @@ fun AllowedInstanceListItem(
 
     LaunchedEffect(Unit) {
         val instanceInfo = try {
-            apClient.getInstanceInfo(item.instanceUrl)
-        } catch (_: Exception) {
+            instanceInfoRepository.getInstanceInfo(item.instanceUrl)
+        } catch (e: Exception) {
+            e.printStackTrace()
             null
         }
 

--- a/app/src/main/java/flights/interstellar/admin/features/connectedInstance/Screen.kt
+++ b/app/src/main/java/flights/interstellar/admin/features/connectedInstance/Screen.kt
@@ -24,10 +24,10 @@ import com.google.accompanist.placeholder.PlaceholderHighlight
 import com.google.accompanist.placeholder.material.fade
 import com.google.accompanist.placeholder.material.placeholder
 import flights.interstellar.admin.R
-import flights.interstellar.admin.api.client.apClient
 import flights.interstellar.admin.api.pojo.InstanceInfo
 import flights.interstellar.admin.common.InterstallarAdminTheme
 import flights.interstellar.admin.common.Purple80
+import flights.interstellar.admin.repository.instanceInfoRepository
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -147,10 +147,11 @@ fun ConnectedInstanceListItem(item: ConnectedInstanceItem) {
         Divider()
     }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(item.instanceUrl) {
         val instanceInfo = try {
-            apClient.getInstanceInfo(item.instanceUrl)
-        } catch (_: Exception) {
+            instanceInfoRepository.getInstanceInfo(item.instanceUrl)
+        } catch (e: Exception) {
+            e.printStackTrace()
             null
         }
 

--- a/app/src/main/java/flights/interstellar/admin/repository/InMemory.kt
+++ b/app/src/main/java/flights/interstellar/admin/repository/InMemory.kt
@@ -1,0 +1,58 @@
+package flights.interstellar.admin.repository
+
+import android.util.Log
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.*
+
+/**
+ * Simple memory based cache, backed with map.
+ */
+class InMemory<K, V> : KVInterface<K, V> {
+    private val backingMap = mutableMapOf<K, ExpiryWrapper<V>>()
+    private val mapAccessMutex = Mutex()
+
+    override suspend fun get(key: K): V? {
+        return mapAccessMutex.withLock {
+            if (!backingMap.containsKey(key)) {
+                Log.v("InMemory", "Get(key: $key) - No key")
+                return@withLock null
+            }
+
+            // Check expiry
+            if (isKeyExpired(key)) {
+                Log.v("InMemory", "Get(key: $key) - Expired")
+                return@withLock null
+            }
+
+            backingMap[key]!!.value
+        }
+    }
+
+    override suspend fun has(key: K): Boolean {
+        return get(key) != null
+    }
+
+    override suspend fun set(key: K, value: V, expiryDurationMs: Long, nowEpoch: Long) {
+        return mapAccessMutex.withLock {
+            Log.v("InMemory", "Set(key: $key, value: $value)")
+            backingMap[key] =
+                ExpiryWrapper(value = value, expiryTimeEpoch = nowEpoch + expiryDurationMs)
+        }
+    }
+
+    private fun isKeyExpired(
+        key: K,
+        nowEpoch: Long = Calendar.getInstance().timeInMillis
+    ): Boolean {
+        Log.v("InMemory", "IsKeyExpired(key: $key")
+        return backingMap[key]!!.expiryTimeEpoch < nowEpoch
+    }
+
+    companion object {
+        private data class ExpiryWrapper<V>(
+            val value: V,
+            val expiryTimeEpoch: Long
+        )
+    }
+}

--- a/app/src/main/java/flights/interstellar/admin/repository/InstanceInfoRepository.kt
+++ b/app/src/main/java/flights/interstellar/admin/repository/InstanceInfoRepository.kt
@@ -1,0 +1,41 @@
+package flights.interstellar.admin.repository
+
+import flights.interstellar.admin.api.client.apClient
+import flights.interstellar.admin.api.pojo.InstanceInfo
+import flights.interstellar.admin.api.pojo.InstanceUrl
+import java.util.concurrent.TimeUnit
+
+val instanceInfoRepository = InstanceInfoRepository()
+
+class InstanceInfoRepository(private val globalExpiryMs: Long = TimeUnit.DAYS.toMillis(7)) {
+    private val inMemoryCache = InMemory<InstanceUrl, InstanceInfo?>()
+
+    suspend fun getInstanceInfo(instanceBaseUrl: InstanceUrl): InstanceInfo {
+        if (!inMemoryCache.has(instanceBaseUrl)) {
+            val instanceInfo = try {
+                apClient.getInstanceInfo(instanceBaseUrl)
+            } catch (_: Exception) {
+                null
+            }
+
+            instanceInfo?.let {
+                inMemoryCache.set(
+                    key = instanceBaseUrl,
+                    value = it,
+                    expiryDurationMs = globalExpiryMs
+                )
+
+                it
+            } ?: run {
+                inMemoryCache.set(
+                    key = instanceBaseUrl,
+                    value = null,
+                    expiryDurationMs = globalExpiryMs
+                )
+            }
+        }
+
+        return inMemoryCache.get(instanceBaseUrl)
+            ?: throw RuntimeException("Simulated API response error")
+    }
+}

--- a/app/src/main/java/flights/interstellar/admin/repository/KVInterface.kt
+++ b/app/src/main/java/flights/interstellar/admin/repository/KVInterface.kt
@@ -1,0 +1,14 @@
+package flights.interstellar.admin.repository
+
+import java.util.*
+
+interface KVInterface<K, V> {
+    suspend fun get(key: K): V?
+    suspend fun has(key: K): Boolean
+    suspend fun set(
+        key: K,
+        value: V,
+        expiryDurationMs: Long,
+        nowEpoch: Long = Calendar.getInstance().timeInMillis
+    )
+}


### PR DESCRIPTION
…for userInfo (not yet used) and instanceInfo to prevent unintended dos attacks

This is a interim solution to this problem. This logic should be migrated and refactored properly after relay fork introduces instance info API. Resolves #2